### PR TITLE
mnt -> mount because consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module sets up a basic Elastic File System on AWS for an account in a speci
 
 ## Default Resources
 
-By default, only the `name` and `vpc_id` are required to be set in order to create the filesystem; however, the `mount_target_subnets` and `mnt_ingress_security_groups` need to be configured in order for the filesystem to actually be usable.
+By default, only the `name` and `vpc_id` are required to be set in order to create the filesystem; however, the `mount_target_subnets` and `mount_ingress_security_groups` need to be configured in order for the filesystem to actually be usable.
 
 ## Inputs
 
@@ -20,8 +20,8 @@ By default, only the `name` and `vpc_id` are required to be set in order to crea
 | internal_record_name | If `internal_zone_id` is provided, Terraform will create a DNS record using the provided `internal_record_name` as the subdomain. If no `internal_record_name` is provided, the convention \"efs-<name>-<environment>\" will be used. | string | `` | no |
 | internal_zone_id | A Route 53 Internal Hosted Zone ID. If provided, a DNS record will be created for the EFS endpoint's DNS name, which can be used to reference the mount target. | string | `` | no |
 | kms_key_arn | The ARN for the KMS key to use for encrypting the disk. If specified, `encrypted` must be set to \"true\"`. If left blank and `encrypted` is set to \"true\", Terraform will use the default `aws/elasticfilesystem` KMS key. | string | `` | no |
-| mnt_ingress_security_groups | List of security group IDs that should be granted ingress for the EFS mount target. | list | `<list>` | no |
-| mnt_ingress_security_groups_count | Number of `mnt_ingress_security_groups` (workaround for `count` not working fully within modules) | string | `0` | no |
+| mount_ingress_security_groups | List of security group IDs that should be granted ingress for the EFS mount target. | list | `<list>` | no |
+| mount_ingress_security_groups_count | Number of `mount_ingress_security_groups` (workaround for `count` not working fully within modules) | string | `0` | no |
 | mount_target_subnets | Subnets in which the EFS mount target will be created. | list | `<list>` | no |
 | mount_target_subnets_count | Number of `mount_target_subnets` (workaround for `count` not working fully within modules) | string | `0` | no |
 | name | A unique name (a maximum of 64 characters are allowed) used as reference when creating the Elastic File System to ensure idempotent file system creation. | string | - | yes |

--- a/examples/with-all-options.tf
+++ b/examples/with-all-options.tf
@@ -42,8 +42,8 @@ module "efs" {
 
   vpc_id = "${module.vpc.vpc_id}"
 
-  mnt_ingress_security_groups       = ["${module.vpc.default_sg}"]
-  mnt_ingress_security_groups_count = 1
+  mount_ingress_security_groups       = ["${module.vpc.default_sg}"]
+  mount_ingress_security_groups_count = 1
 
   mount_target_subnets       = ["${module.vpc.private_subnets}"]
   mount_target_subnets_count = 2

--- a/main.tf
+++ b/main.tf
@@ -19,15 +19,15 @@ resource "aws_efs_file_system" "fs" {
   tags = "${merge(local.base_tags, map("Name", var.name), var.custom_tags)}"
 }
 
-resource "aws_efs_mount_target" "mnt" {
+resource "aws_efs_mount_target" "mount" {
   count = "${var.mount_target_subnets_count}"
 
   file_system_id  = "${aws_efs_file_system.fs.id}"
   subnet_id       = "${element(var.mount_target_subnets, count.index)}"
-  security_groups = ["${aws_security_group.mnt.id}"]
+  security_groups = ["${aws_security_group.mount.id}"]
 }
 
-resource "aws_security_group" "mnt" {
+resource "aws_security_group" "mount" {
   name        = "${var.name}"
   description = "Security group dedicated to the ${var.name} EFS mount target."
   vpc_id      = "${var.vpc_id}"
@@ -35,24 +35,24 @@ resource "aws_security_group" "mnt" {
   tags = "${merge(local.base_tags, map("Name", var.name), var.custom_tags)}"
 }
 
-resource "aws_security_group_rule" "mnt_ingress" {
-  count = "${var.mnt_ingress_security_groups_count}"
+resource "aws_security_group_rule" "mount_ingress" {
+  count = "${var.mount_ingress_security_groups_count}"
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 2049
   to_port                  = 2049
-  security_group_id        = "${aws_security_group.mnt.id}"
-  source_security_group_id = "${element(var.mnt_ingress_security_groups, count.index)}"
+  security_group_id        = "${aws_security_group.mount.id}"
+  source_security_group_id = "${element(var.mount_ingress_security_groups, count.index)}"
 }
 
-resource "aws_security_group_rule" "mnt_egress" {
+resource "aws_security_group_rule" "mount_egress" {
   type              = "egress"
   protocol          = -1
   from_port         = 0
   to_port           = 0
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.mnt.id}"
+  security_group_id = "${aws_security_group.mount.id}"
 }
 
 locals {

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,17 +17,17 @@ output "filesystem_dns_name" {
 ##########################
 
 output "mount_target_id" {
-  value       = "${aws_efs_mount_target.mnt.*.id}"
+  value       = "${aws_efs_mount_target.mount.*.id}"
   description = "The ID of the mount target"
 }
 
 output "mount_target_dns_name" {
-  value       = "${aws_efs_mount_target.mnt.*.dns_name}"
+  value       = "${aws_efs_mount_target.mount.*.dns_name}"
   description = "The DNS name for the mount target in a given subnet/AZ"
 }
 
 output "mount_target_network_interface_id" {
-  value       = "${aws_efs_mount_target.mnt.*.network_interface_id}"
+  value       = "${aws_efs_mount_target.mount.*.network_interface_id}"
   description = "The ID of the network interface automatically created for the mount target"
 }
 
@@ -36,7 +36,7 @@ output "mount_target_network_interface_id" {
 #########################################
 
 output "mount_target_security_group_id" {
-  value       = "${aws_security_group.mnt.id}"
+  value       = "${aws_security_group.mount.id}"
   description = "ID of the security group created for the EFS mount target"
 }
 

--- a/tests/with-all-options/main.tf
+++ b/tests/with-all-options/main.tf
@@ -42,8 +42,8 @@ module "efs" {
 
   vpc_id = "${module.vpc.vpc_id}"
 
-  mnt_ingress_security_groups       = ["${module.vpc.default_sg}"]
-  mnt_ingress_security_groups_count = 1
+  mount_ingress_security_groups       = ["${module.vpc.default_sg}"]
+  mount_ingress_security_groups_count = 1
 
   mount_target_subnets       = ["${module.vpc.private_subnets}"]
   mount_target_subnets_count = 2

--- a/variables.tf
+++ b/variables.tf
@@ -81,14 +81,14 @@ variable "vpc_id" {
   type        = "string"
 }
 
-variable "mnt_ingress_security_groups" {
+variable "mount_ingress_security_groups" {
   description = "List of security group IDs that should be granted ingress for the EFS mount target."
   type        = "list"
   default     = []
 }
 
-variable "mnt_ingress_security_groups_count" {
-  description = "Number of `mnt_ingress_security_groups` (workaround for `count` not working fully within modules)"
+variable "mount_ingress_security_groups_count" {
+  description = "Number of `mount_ingress_security_groups` (workaround for `count` not working fully within modules)"
   type        = "string"
   default     = "0"
 }


### PR DESCRIPTION
Someone called out that I was using both `mnt` and `mount`, and now I can't unsee it.