### PR TITLE
Update module source refs to SSH

### DIFF
--- a/examples/minimal-options-unencrypted.tf
+++ b/examples/minimal-options-unencrypted.tf
@@ -4,13 +4,13 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "github.com/rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.2"
 
   vpc_name = "EFSTest-minimal-options-unencrypted-1VPC"
 }
 
 module "efs" {
-  source = "github.com/rackspace-infrastructure-automation/aws-terraform-efs//?ref=<specify_version_here>"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=<specify_version_here>"
 
   name      = "EFSTest-minimal-options-unencrypted"
   encrypted = "false"

--- a/examples/with-all-options.tf
+++ b/examples/with-all-options.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "github.com/rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.2"
 
   vpc_name = "EFSTest-with-all-options"
 }
@@ -28,7 +28,7 @@ resource "aws_sns_topic" "efs_burst_ok" {
 }
 
 module "efs" {
-  source = "github.com/rackspace-infrastructure-automation/aws-terraform-efs//?ref=<specify_version_here>"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=<specify_version_here>"
 
   name                            = "EFSTest-with-all-options"
   performance_mode                = "maxIO"

--- a/tests/minimal-options-unencrypted/main.tf
+++ b/tests/minimal-options-unencrypted/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "github.com/rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.2"
 
   vpc_name = "EFSTest-minimal-options-unencrypted-1VPC"
 }

--- a/tests/with-all-options/main.tf
+++ b/tests/with-all-options/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "github.com/rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.2"
 
   vpc_name = "EFSTest-with-all-options"
 }


### PR DESCRIPTION
Updates all module source references using HTTP syntax to the SSH syntax.

related issue: rackspace-infrastructure-automation/aws-terraform-internal#155