### PR TITLE
Implement CWAlarm module for EFS alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module sets up a basic Elastic File System on AWS for an account in a speci
 
 ```
 module "efs" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=v0.0.4"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=v0.0.5"
 
  name      = "EFSTest-minimal-options-unencrypted"
  encrypted = "false"
@@ -23,8 +23,6 @@ Full working references are available at [examples](examples)
 |------|-------------|:----:|:-----:|:-----:|
 | create\_internal\_dns\_record | Whether or not to create a custom, internal DNS record for the EFS endpoint's generated DNS name. If \"true\", the `internal_zone_id` MUST be provided, and a specific `internal_record_name` MAY be provided. Default is \"false\". | string | `"false"` | no |
 | create\_parameter\_store\_entries | Whether or not to create EC2 Parameter Store entries to expose the EFS DNS name and Filesystem ID. | string | `"true"` | no |
-| custom\_alarm\_sns\_topic | If not Rackspace managed, you can use custom SNS topics to send the Alarm actions to. | list | `<list>` | no |
-| custom\_ok\_sns\_topic | If not Rackspace managed, you can use custom SNS topics to send the OK actions to. | list | `<list>` | no |
 | custom\_tags | Optional tags to be applied on top of the base tags on all resources | map | `<map>` | no |
 | cw\_burst\_credit\_period | The number of periods over which the EFS Burst Credit level is compared to the specified threshold. | string | `"12"` | no |
 | cw\_burst\_credit\_threshold | The minimum EFS Burst Credit level before generating an alarm. | string | `"1000000000000"` | no |
@@ -38,9 +36,11 @@ Full working references are available at [examples](examples)
 | mount\_target\_subnets | Subnets in which the EFS mount target will be created. | list | `<list>` | no |
 | mount\_target\_subnets\_count | Number of `mount_target_subnets` (workaround for `count` not working fully within modules) | string | `"0"` | no |
 | name | A unique name (a maximum of 64 characters are allowed) used as reference when creating the Elastic File System to ensure idempotent file system creation. | string | n/a | yes |
+| notification\_topic | List of SNS Topic ARNs to use for customer notifications. | list | `<list>` | no |
 | performance\_mode | The file system performance mode. Can be either "generalPurpose" or "maxIO". | string | `"generalPurpose"` | no |
 | provisioned\_throughput\_in\_mibps | The throughput, measured in MiB/s, that you want to provision for the file system. **NOTE**: Setting a non-zero value will automatically enable \"provisioned\" throughput mode. To use \"bursting\" `throughput mode, leave this value set to \"0\". | string | `"0"` | no |
-| rackspace\_managed | Whether or not the filesystem will be managed by Rackspace support teams and create CloudWatch alarms that generate support tickets. | string | `"true"` | no |
+| rackspace\_alarms\_enabled | Specifies whether alarms will create a Rackspace ticket.  Ignored if rackspace_managed is set to false. | string | `"false"` | no |
+| rackspace\_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | string | `"true"` | no |
 | vpc\_id | The VPC ID. | string | n/a | yes |
 
 ## Outputs

--- a/examples/minimal-options-unencrypted.tf
+++ b/examples/minimal-options-unencrypted.tf
@@ -10,7 +10,7 @@ module "vpc" {
 }
 
 module "efs" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=v0.0.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=v0.0.5"
 
   name      = "EFSTest-minimal-options-unencrypted"
   encrypted = "false"

--- a/examples/with-all-options.tf
+++ b/examples/with-all-options.tf
@@ -28,7 +28,7 @@ resource "aws_sns_topic" "efs_burst_ok" {
 }
 
 module "efs" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=v0.0.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=v0.0.5"
 
   name                            = "EFSTest-with-all-options"
   performance_mode                = "maxIO"

--- a/tests/minimal-options-unencrypted/main.tf
+++ b/tests/minimal-options-unencrypted/main.tf
@@ -3,16 +3,24 @@ provider "aws" {
   region  = "us-west-2"
 }
 
+resource "random_string" "res_name" {
+  length  = 8
+  upper   = false
+  lower   = true
+  special = false
+  number  = false
+}
+
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=master"
 
-  vpc_name = "EFSTest-minimal-options-unencrypted-1VPC"
+  vpc_name = "EFSTest-minimal-options-${random_string.res_name.result}"
 }
 
 module "efs" {
   source = "../../module"
 
-  name      = "EFSTest-minimal-options-unencrypted"
+  name      = "EFSTest-minimal-options-${random_string.res_name.result}"
   encrypted = "false"
 
   vpc_id = "${module.vpc.vpc_id}"

--- a/variables.tf
+++ b/variables.tf
@@ -109,26 +109,22 @@ variable "cw_burst_credit_threshold" {
   default     = "1000000000000"
 }
 
+variable "notification_topic" {
+  description = "List of SNS Topic ARNs to use for customer notifications."
+  type        = "list"
+  default     = []
+}
+
 variable "rackspace_managed" {
-  description = <<EOF
-Whether or not the filesystem will be managed by Rackspace support teams and create CloudWatch alarms that generate
-support tickets.
-EOF
-
-  type    = "string"
-  default = "true"
+  description = "Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents."
+  type        = "string"
+  default     = true
 }
 
-variable "custom_alarm_sns_topic" {
-  description = "If not Rackspace managed, you can use custom SNS topics to send the Alarm actions to."
-  type        = "list"
-  default     = []
-}
-
-variable "custom_ok_sns_topic" {
-  description = "If not Rackspace managed, you can use custom SNS topics to send the OK actions to."
-  type        = "list"
-  default     = []
+variable "rackspace_alarms_enabled" {
+  description = "Specifies whether alarms will create a Rackspace ticket.  Ignored if rackspace_managed is set to false."
+  type        = "string"
+  default     = false
 }
 
 #######################


### PR DESCRIPTION
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/191
##### Summary of change(s):
Replaces `aws_cloudwatch_metric_alarm` resource with call to aws-terraform-cloudwatch_alarm module
##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
Yes, replacement will occur due to state file path change
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Yes, readme has been updated.
##### Do examples need to be updated based on changes?
Yes, pinned version in examples updated.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.