### PR TITLE
update security group naming schema

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,11 +49,15 @@ resource "aws_efs_mount_target" "mount" {
 }
 
 resource "aws_security_group" "mount" {
-  name        = "${var.name}"
+  name_prefix = "${var.name}-EfsSecurityGroup"
   description = "Security group dedicated to the ${var.name} EFS mount target."
   vpc_id      = "${var.vpc_id}"
 
-  tags = "${merge(local.base_tags, map("Name", var.name), var.custom_tags)}"
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = "${merge(local.base_tags, map("Name", "${var.name}-EfsSecurityGroup"), var.custom_tags)}"
 }
 
 resource "aws_security_group_rule" "mount_ingress" {


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
fixes https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/211
##### Summary of change(s):
Changes the security group to be like the other security group naming structure. 
Because of issues with destroying a recreated security group resource dependency we had to add a create before destroy to make this work properly.
See issue: https://github.com/terraform-providers/terraform-provider-aws/issues/1671
See failed CI run for this update without create_before_destroy https://circleci.com/gh/rackspace-infrastructure-automation/aws-terraform-efs/53

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
yes, it will because of name structure changes. This makes it more in-line with other security group naming schemas

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
no
##### If input variables or output variables have changed or has been added, have you updated the README?
none

##### Do examples need to be updated based on changes?
no
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.