### PR TITLE
Remove module based security group creation, force user to provide SG ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ This module sets up a basic Elastic File System on AWS for an account in a speci
 
 ## Basic Usage
 
-```
+```HCL
 module "efs" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=v0.0.5"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=v0.0.7"
 
- name      = "EFSTest-minimal-options-unencrypted"
- encrypted = "false"
-
- vpc_id = "${module.vpc.vpc_id}"
+  encrypted       = "false"
+  name            = "EFSTest-minimal-options-unencrypted"
+  security_groups = ["${aws_security_group.efs.id}"]
+  vpc_id          = "${module.vpc.vpc_id}"
 }
 ```
 
@@ -31,8 +31,6 @@ Full working references are available at [examples](examples)
 | internal\_record\_name | If `internal_zone_id` is provided, Terraform will create a DNS record using the provided `internal_record_name` as the subdomain. If no `internal_record_name` is provided, the convention \"efs-<name>-<environment>\" will be used. | string | `""` | no |
 | internal\_zone\_id | A Route 53 Internal Hosted Zone ID. If provided, a DNS record will be created for the EFS endpoint's DNS name, which can be used to reference the mount target. | string | `""` | no |
 | kms\_key\_arn | The ARN for the KMS key to use for encrypting the disk. If specified, `encrypted` must be set to \"true\"`. If left blank and `encrypted` is set to \"true\", Terraform will use the default `aws/elasticfilesystem` KMS key. | string | `""` | no |
-| mount\_ingress\_security\_groups | List of security group IDs that should be granted ingress for the EFS mount target. | list | `<list>` | no |
-| mount\_ingress\_security\_groups\_count | Number of `mount_ingress_security_groups` (workaround for `count` not working fully within modules) | string | `"0"` | no |
 | mount\_target\_subnets | Subnets in which the EFS mount target will be created. | list | `<list>` | no |
 | mount\_target\_subnets\_count | Number of `mount_target_subnets` (workaround for `count` not working fully within modules) | string | `"0"` | no |
 | name | A unique name (a maximum of 64 characters are allowed) used as reference when creating the Elastic File System to ensure idempotent file system creation. | string | n/a | yes |
@@ -41,6 +39,7 @@ Full working references are available at [examples](examples)
 | provisioned\_throughput\_in\_mibps | The throughput, measured in MiB/s, that you want to provision for the file system. **NOTE**: Setting a non-zero value will automatically enable \"provisioned\" throughput mode. To use \"bursting\" `throughput mode, leave this value set to \"0\". | string | `"0"` | no |
 | rackspace\_alarms\_enabled | Specifies whether alarms will create a Rackspace ticket.  Ignored if rackspace_managed is set to false. | string | `"false"` | no |
 | rackspace\_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | string | `"true"` | no |
+| security\_groups | A list of EC2 security groups to assign to this resource | list | n/a | yes |
 | vpc\_id | The VPC ID. | string | n/a | yes |
 
 ## Outputs
@@ -55,5 +54,4 @@ Full working references are available at [examples](examples)
 | mount\_target\_id | The ID of the mount target |
 | mount\_target\_internal\_r53\_record | Internal Route 53 record FQDN for the EFS mount target |
 | mount\_target\_network\_interface\_id | The ID of the network interface automatically created for the mount target |
-| mount\_target\_security\_group\_id | ID of the security group created for the EFS mount target |
 

--- a/examples/minimal-options-unencrypted.tf
+++ b/examples/minimal-options-unencrypted.tf
@@ -4,16 +4,74 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
 
   vpc_name = "EFSTest-minimal-options-unencrypted-1VPC"
 }
 
+resource "aws_security_group" "sftp" {
+  name_prefix = "SFTP-"
+  vpc_id      = "${module.vpc.vpc_id}"
+
+  description = "Access to SFTP instance(s)"
+
+  tags = {
+    Name = "SFTP"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "sftp_egress_all" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.sftp.id}"
+}
+
+resource "aws_security_group" "efs" {
+  name_prefix = "EFS-"
+  vpc_id      = "${module.vpc.vpc_id}"
+
+  description = "Access to EFS mount targets"
+
+  tags = {
+    Name = "EFS"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "efs_egress_all" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.efs.id}"
+}
+
+resource "aws_security_group_rule" "efs_ingress_tcp_2049_sftp" {
+  type                     = "ingress"
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.sftp.id}"
+  security_group_id        = "${aws_security_group.efs.id}"
+  description              = "Ingress from sftp (TCP:2049)"
+}
+
 module "efs" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=v0.0.5"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-efs//?ref=v0.0.7"
 
-  name      = "EFSTest-minimal-options-unencrypted"
-  encrypted = "false"
-
-  vpc_id = "${module.vpc.vpc_id}"
+  encrypted       = "false"
+  name            = "EFSTest-minimal-options-unencrypted"
+  security_groups = ["${aws_security_group.efs.id}"]
+  vpc_id          = "${module.vpc.vpc_id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,15 +31,6 @@ output "mount_target_network_interface_id" {
   description = "The ID of the network interface automatically created for the mount target"
 }
 
-#########################################
-# EFS Mount Target Security Group Outputs
-#########################################
-
-output "mount_target_security_group_id" {
-  value       = "${aws_security_group.mount.id}"
-  description = "ID of the security group created for the EFS mount target"
-}
-
 #######################
 # Conditional Resources
 #######################

--- a/tests/minimal-options-unencrypted/main.tf
+++ b/tests/minimal-options-unencrypted/main.tf
@@ -17,11 +17,36 @@ module "vpc" {
   vpc_name = "EFSTest-minimal-options-${random_string.res_name.result}"
 }
 
+resource "aws_security_group" "efs" {
+  name_prefix = "EFS-"
+  vpc_id      = "${module.vpc.vpc_id}"
+
+  description = "Access to EFS mount targets"
+
+  tags = {
+    Name = "EFS"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "efs_egress_all" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.efs.id}"
+}
+
 module "efs" {
   source = "../../module"
 
   name      = "EFSTest-minimal-options-${random_string.res_name.result}"
   encrypted = "false"
 
-  vpc_id = "${module.vpc.vpc_id}"
+  security_groups = ["${aws_security_group.efs.id}"]
+  vpc_id          = "${module.vpc.vpc_id}"
 }

--- a/tests/outputs.tf
+++ b/tests/outputs.tf
@@ -31,15 +31,6 @@ output "mount_target_network_interface_id" {
   description = "The ID of the network interface automatically created for the mount target"
 }
 
-#########################################
-# EFS Mount Target Security Group Outputs
-#########################################
-
-output "mount_target_security_group_id" {
-  value       = "${module.efs.mount_target_security_group_id}"
-  description = "ID of the security group created for the EFS mount target"
-}
-
 #######################
 # Conditional Resources
 #######################

--- a/variables.tf
+++ b/variables.tf
@@ -76,21 +76,14 @@ variable "mount_target_subnets_count" {
   default     = "0"
 }
 
+variable "security_groups" {
+  description = "A list of EC2 security groups to assign to this resource"
+  type        = "list"
+}
+
 variable "vpc_id" {
   description = "The VPC ID."
   type        = "string"
-}
-
-variable "mount_ingress_security_groups" {
-  description = "List of security group IDs that should be granted ingress for the EFS mount target."
-  type        = "list"
-  default     = []
-}
-
-variable "mount_ingress_security_groups_count" {
-  description = "Number of `mount_ingress_security_groups` (workaround for `count` not working fully within modules)"
-  type        = "string"
-  default     = "0"
 }
 
 ################################


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/224
##### Summary of change(s):

- remove previous security group methods
- add new variable to pass in a list of SG IDs for the mount targets
- update README, tests, examples

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

Yes, this should not be considered backwards compatible as it will tear down existing security groups and you will need to handle creation of a new group, with rules, and pass it in to this new version.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes

##### Do examples need to be updated based on changes?

Yes, done

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.